### PR TITLE
Update sinatra dependency to 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.2.0
+## 3.1.0
   - Update sinatra dependency to 2.x [#19](https://github.com/logstash-plugins/logstash-output-websocket/pull/19)
 
 ## 3.0.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.2.0
+  - Update sinatra dependency to 2.x [#19](https://github.com/logstash-plugins/logstash-output-websocket/pull/19)
+
 ## 3.0.5
   - Docs: Set the default_codec doc attribute.
 

--- a/logstash-output-websocket.gemspec
+++ b/logstash-output-websocket.gemspec
@@ -23,7 +23,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
   s.add_runtime_dependency 'sinatra', '~> 2'
-  s.add_runtime_dependency 'ftw', ['~> 0.0.46']
+  s.add_runtime_dependency 'ftw', '~> 0.0.46'
+  s.add_runtime_dependency 'http_parser.rb', '~> 0.6.0'
 
   s.add_development_dependency 'logstash-devutils'
 end

--- a/logstash-output-websocket.gemspec
+++ b/logstash-output-websocket.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-websocket'
-  s.version         = '3.0.5'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Publishes messages to a websocket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core-plugin-api", ">= 1.60", "<= 2.99"
   s.add_runtime_dependency 'logstash-codec-plain'
-  s.add_runtime_dependency 'sinatra', '~> 1.4.6'
+  s.add_runtime_dependency 'sinatra', '~> 2'
   s.add_runtime_dependency 'ftw', ['~> 0.0.46']
 
   s.add_development_dependency 'logstash-devutils'

--- a/logstash-output-websocket.gemspec
+++ b/logstash-output-websocket.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-websocket'
-  s.version         = '3.1.0'
+  s.version         = '3.2.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Publishes messages to a websocket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/logstash-output-websocket.gemspec
+++ b/logstash-output-websocket.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name            = 'logstash-output-websocket'
-  s.version         = '3.2.0'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "Publishes messages to a websocket"
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"


### PR DESCRIPTION
Tested locally with:
`bin/logstash -e "output { websocket { } }"`

And a client:

```
WebSocket::Client::Simple.connect 'ws://127.0.0.1:3232' do |ws|
  ws.on :open do
    puts "connect!"
  end

  ws.on :message do |msg|
    puts msg.data
  end
end
```

fixes #15, #16, #17, #18, https://github.com/elastic/logstash/issues/15786